### PR TITLE
Fix front-controller deletion for "Symfony" template

### DIFF
--- a/01-symfony.yaml
+++ b/01-symfony.yaml
@@ -48,7 +48,7 @@ template: |
             set -x -e
 
             # Remove the development front-controller if present
-            (>&2 rm web/{{.FrontController}}_dev.php)
+            (>&2 rm {{.PublicDirectory}}/index_dev.php {{.PublicDirectory}}/app_dev.php)
 
             SYMFONY_ENV=prod composer install --prefer-dist --optimize-autoloader --classmap-authoritative --no-progress --no-ansi --no-interaction --no-dev
             (>&2 SYMFONY_ENV=prod bin/console cache:clear --no-warmup)


### PR DESCRIPTION
It makes this logic in-par with the Configurator behavior.