### PR TITLE
Change the app default name to be app

### DIFF
--- a/00-flex.yaml
+++ b/00-flex.yaml
@@ -5,7 +5,7 @@ requirements:
     value: symfony/flex
 
 template: |
-    name: {{.Slug}}
+    name: app
 
     type: php:{{.PhpVersion}}
 

--- a/01-silex.yaml
+++ b/01-silex.yaml
@@ -5,7 +5,7 @@ requirements:
     value: silex/silex
 
 template: |
-    name: {{.Slug}}
+    name: app
 
     type: php:{{.PhpVersion}}
 

--- a/01-symfony.yaml
+++ b/01-symfony.yaml
@@ -5,7 +5,7 @@ requirements:
     value: symfony/symfony
 
 template: |
-    name: {{.Slug}}
+    name: app
 
     type: php:{{.PhpVersion}}
 

--- a/99-default.yaml
+++ b/99-default.yaml
@@ -1,7 +1,7 @@
 requirements:
 
 template: |
-    name: {{.Slug}}
+    name: app
 
     type: php:{{.PhpVersion}}
 


### PR DESCRIPTION
It's easier for documentation and having something else than app is only ever useful for multi-app projects, which is not something common anyway.
