### PR TITLE
Fix default extensions

### DIFF
--- a/00-flex.yaml
+++ b/00-flex.yaml
@@ -11,9 +11,15 @@ template: |
 
     runtime:
         extensions:
+            {{ if php_extension_available "apcu" $.PhpVersion -}}
             - apcu
+            {{ end -}}
+            {{- if php_extension_available "mbstring" $.PhpVersion -}}
             - mbstring
+            {{ end -}}
+            {{- if php_extension_available "sodium" $.PhpVersion -}}
             - sodium
+            {{ end -}}
             {{ range $ext := php_extensions -}}
             {{- if php_extension_available $ext $.PhpVersion -}}
             - {{ $ext }}

--- a/01-silex.yaml
+++ b/01-silex.yaml
@@ -11,9 +11,15 @@ template: |
 
     runtime:
         extensions:
+            {{ if php_extension_available "apcu" $.PhpVersion -}}
             - apcu
+            {{ end -}}
+            {{- if php_extension_available "mbstring" $.PhpVersion -}}
             - mbstring
+            {{ end -}}
+            {{- if php_extension_available "sodium" $.PhpVersion -}}
             - sodium
+            {{ end -}}
             {{ range $ext := php_extensions -}}
             {{- if php_extension_available $ext $.PhpVersion -}}
             - {{ $ext }}

--- a/01-symfony.yaml
+++ b/01-symfony.yaml
@@ -11,9 +11,15 @@ template: |
 
     runtime:
         extensions:
+            {{ if php_extension_available "apcu" $.PhpVersion -}}
             - apcu
+            {{ end -}}
+            {{- if php_extension_available "mbstring" $.PhpVersion -}}
             - mbstring
+            {{ end -}}
+            {{- if php_extension_available "sodium" $.PhpVersion -}}
             - sodium
+            {{ end -}}
             {{ range $ext := php_extensions -}}
             {{- if php_extension_available $ext $.PhpVersion -}}
             - {{ $ext }}


### PR DESCRIPTION
Default extensions are not always available (`sodium` requires PHP >= 7.2 and `mbstring` requires PHP >= 7.0