### PR TITLE
Recommended value for "opcache.memory_consumption"

### DIFF
--- a/php.ini
+++ b/php.ini
@@ -6,3 +6,4 @@ max_execution_time=30
 session.use_strict_mode=On
 realpath_cache_ttl=3600
 zend.detect_unicode=Off
+opcache.memory_consumption=128


### PR DESCRIPTION
Based on https://www.php.net/manual/en/opcache.configuration.php,
one should use 128MB instead of 64MB starting from 7.0.0