### PR TITLE
Tweak default FPM config

### DIFF
--- a/00-flex.yaml
+++ b/00-flex.yaml
@@ -10,6 +10,7 @@ template: |
     type: php:{{.PhpVersion}}
 
     runtime:
+        decorate_workers_output: no
         extensions:
             {{ if php_extension_available "apcu" $.PhpVersion -}}
             - apcu


### PR DESCRIPTION
As of PHP 7.3, this setting allows to remove the warning preprended to logs. That's very useful when logging to stderr instead of a file.
