### PR TITLE
Move preloading config

### DIFF
--- a/00-flex.yaml
+++ b/00-flex.yaml
@@ -26,6 +26,11 @@ template: |
             {{ end -}}
             {{- end }}
 
+    variables:
+        php:
+            # uncomment on PHP 7.4+, needs Symfony 4.4.14+, 5.1.6+, or 5.2+
+            #opcache.preload: /app/src/.preload.php
+
     build:
         flavor: none
 

--- a/php.ini
+++ b/php.ini
@@ -6,5 +6,3 @@ max_execution_time=30
 session.use_strict_mode=On
 realpath_cache_ttl=3600
 zend.detect_unicode=Off
-# uncomment on PHP 7.4+, needs Symfony 4.4.14+, 5.1.6+, or 5.2+
-#opcache.preload=/app/src/.preload.php


### PR DESCRIPTION
It's better for several reasons: first, it's only suggested when using the flex template (so does not pollute projects not using Symfony 4+), then, it's only used in the Cloud and so preloading is not used locally, which is probably better in dev.
