### PR TITLE
Add support for Symfony Demo

### DIFF
--- a/30-symfony-flex.yaml
+++ b/30-symfony-flex.yaml
@@ -60,7 +60,10 @@ template: |
 
     mounts:
         "/var": { source: local, source_path: var }
-
+        {{ if file_exists "templates/debug/source_code.html.twig" -}}
+        "/data": { source: local, source_path: "data" }
+        {{- end -}}
+        
     hooks:
         build: |
             set -x -e


### PR DESCRIPTION
Even if `symfonycorp/platformsh-meta` is missing.

See https://github.com/symfony-cli/symfony-cli/issues/202