### PR TITLE
Optimize upsun mounts for Symfony cache and pools

### DIFF
--- a/upsun/15-symfony-flex-upsun.yaml
+++ b/upsun/15-symfony-flex-upsun.yaml
@@ -47,7 +47,10 @@ template: |
                         passthru: "/{{.FrontController}}"
 
             mounts:
-                "/var": { source: storage, source_path: var }
+                "/var/cache": { source: instance, source_path: var/cache }
+                "/var/cache/prod": { source: instance, source_path: var/cache/prod }
+                "/var/cache/prod/pools": { source: instance, source_path: var/cache/prod/pools }
+                "/var/cache/prod/pools/app": { source: storage, source_path: var/cache/prod/pools/app }
                 {{ if file_exists "templates/debug/source_code.html.twig" -}}
                 "/data": { source: storage, source_path: "data" }
                 {{- end }}


### PR DESCRIPTION
#37 was reverted because the `var/cache/prod` and `var/cache/prod/pools` belong to `root:root`.

This PR works around the issue by turning these dirs into explicit mounts.
Confirmed to work on a test project.

/cc @flovntp (ideally this wouldn't be required, dunno if that's something the host can fix?)