### PR TITLE
change Upsun deprecated config cmd to commands.start for Crons

### DIFF
--- a/30-symfony-flex.yaml
+++ b/30-symfony-flex.yaml
@@ -67,11 +67,11 @@ template: |
         security-check:
             # Check that no security issues have been found for PHP packages deployed in production
             spec: '50 23 * * *'
-            commands: 
+            commands:
                 start: if [ "$PLATFORM_ENVIRONMENT_TYPE" = "production" ]; then croncape COMPOSER_ROOT_VERSION=1.0.0 COMPOSER_AUDIT_ABANDONED=ignore composer audit --no-cache; fi
         clean-expired-sessions:
             spec: '17,47 * * * *'
-            commands: 
+            commands:
                 start: croncape php-session-clean
 
     {{ if has_composer_package "symfony/messenger" -}}

--- a/30-symfony-flex.yaml
+++ b/30-symfony-flex.yaml
@@ -67,10 +67,12 @@ template: |
         security-check:
             # Check that no security issues have been found for PHP packages deployed in production
             spec: '50 23 * * *'
-            cmd: if [ "$PLATFORM_ENVIRONMENT_TYPE" = "production" ]; then croncape COMPOSER_ROOT_VERSION=1.0.0 COMPOSER_AUDIT_ABANDONED=ignore composer audit --no-cache; fi
+            commands: 
+                start: if [ "$PLATFORM_ENVIRONMENT_TYPE" = "production" ]; then croncape COMPOSER_ROOT_VERSION=1.0.0 COMPOSER_AUDIT_ABANDONED=ignore composer audit --no-cache; fi
         clean-expired-sessions:
             spec: '17,47 * * * *'
-            cmd: croncape php-session-clean
+            commands: 
+                start: croncape php-session-clean
 
     {{ if has_composer_package "symfony/messenger" -}}
     workers:

--- a/60-symfony-without-flex.yaml
+++ b/60-symfony-without-flex.yaml
@@ -77,10 +77,12 @@ template: |
         security-check:
             # Check that no security issues have been found for PHP packages deployed in production
             spec: '50 23 * * *'
-            cmd: if [ "$PLATFORM_ENVIRONMENT_TYPE" = "production" ]; then croncape COMPOSER_ROOT_VERSION=1.0.0 COMPOSER_AUDIT_ABANDONED=ignore composer audit --no-cache; fi
+            commands:
+                start: if [ "$PLATFORM_ENVIRONMENT_TYPE" = "production" ]; then croncape COMPOSER_ROOT_VERSION=1.0.0 COMPOSER_AUDIT_ABANDONED=ignore composer audit --no-cache; fi
         clean-expired-sessions:
             spec: '17,47 * * * *'
-            cmd: croncape php-session-clean
+            commands:
+                start: croncape php-session-clean
 
 extra_files:
   "app/config/parameters_symfonycloud.php": |

--- a/upsun/10-sulu-upsun.yaml
+++ b/upsun/10-sulu-upsun.yaml
@@ -116,10 +116,12 @@ template: |
                 security-check:
                     # Check that no security issues have been found for PHP packages deployed in production
                     spec: '50 23 * * *'
-                    cmd: if [ "$PLATFORM_ENVIRONMENT_TYPE" = "production" ]; then croncape COMPOSER_ROOT_VERSION=1.0.0 COMPOSER_AUDIT_ABANDONED=ignore composer audit --no-cache; fi
+                    commands:
+                        start: if [ "$PLATFORM_ENVIRONMENT_TYPE" = "production" ]; then croncape COMPOSER_ROOT_VERSION=1.0.0 COMPOSER_AUDIT_ABANDONED=ignore composer audit --no-cache; fi
                 clean-expired-sessions:
                     spec: '17,47 * * * *'
-                    cmd: croncape php-session-clean
+                    commands:
+                        start: croncape php-session-clean
 
             {{ if has_composer_package "symfony/messenger" -}}
             workers:

--- a/upsun/15-symfony-flex-upsun.yaml
+++ b/upsun/15-symfony-flex-upsun.yaml
@@ -83,10 +83,12 @@ template: |
                 security-check:
                     # Check that no security issues have been found for PHP packages deployed in production
                     spec: '50 23 * * *'
-                    cmd: if [ "$PLATFORM_ENVIRONMENT_TYPE" = "production" ]; then croncape COMPOSER_ROOT_VERSION=1.0.0 COMPOSER_AUDIT_ABANDONED=ignore composer audit --no-cache; fi
+                    commands:
+                        start: if [ "$PLATFORM_ENVIRONMENT_TYPE" = "production" ]; then croncape COMPOSER_ROOT_VERSION=1.0.0 COMPOSER_AUDIT_ABANDONED=ignore composer audit --no-cache; fi
                 clean-expired-sessions:
                     spec: '17,47 * * * *'
-                    cmd: croncape php-session-clean
+                    commands:
+                        start: croncape php-session-clean
 
             {{ if has_composer_package "symfony/messenger" -}}
             workers:


### PR DESCRIPTION
`cmd` YAML config has been deprecated, we now need to use:
```
applications:
  app:
    crons:
      security-check:
        commands:
          start: //...
```
cf. https://docs.upsun.com/create-apps/image-properties/crons.html (and https://fixed.docs.upsun.com/create-apps/image-properties/crons.html)
<img width="680" height="129" alt="Screenshot 2026-01-29 at 09 46 57" src="https://github.com/user-attachments/assets/d2c682f0-6896-4511-9fec-742fc6269598" />

